### PR TITLE
feat: add a `skipAutoLaunch` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ export default defineConfig({
     webExtension({
       watchFilePaths: [
         path.resolve(__dirname, "tailwind.config.js")
-      ]
+      ],
+      skipAutoInstall: false // default is false
     }),
   ],
 });
@@ -179,6 +180,8 @@ export default defineConfig({
 > Watch mode will not reload properly when the manifest changes. You'll need to restart the `vite build --watch` command use the updated manifest.
 >
 > This is a limitation of [`web-ext`](https://www.npmjs.com/package/web-ext)
+>
+> Set `skipAutoInstall` to `true` to skip the automatic installation of the extension.
 
 ### Additional Inputs
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ export default defineConfig({
       watchFilePaths: [
         path.resolve(__dirname, "tailwind.config.js")
       ],
-      skipAutoInstall: false // default is false
+      disableAutoLaunch: false // default is false
     }),
   ],
 });
@@ -180,8 +180,8 @@ export default defineConfig({
 > Watch mode will not reload properly when the manifest changes. You'll need to restart the `vite build --watch` command use the updated manifest.
 >
 > This is a limitation of [`web-ext`](https://www.npmjs.com/package/web-ext)
->
-> Set `skipAutoInstall` to `true` to skip the automatic installation of the extension.
+
+Set `disableAutoLaunch` to `true` to skip the automatic installation of the extension.
 
 ### Additional Inputs
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -58,7 +58,7 @@ interface BrowserExtensionPluginOptions {
   /**
    * Used to disable auto-installing the extension when in watch mode. Default value is `false`.
    */
-  skipAutoInstall?: boolean;
+  disableAutoLaunch?: boolean;
 
   /**
    * **Absolute paths** to files to watch.
@@ -301,7 +301,7 @@ export default function browserExtension<T>(
   }
 
   const browser = options.browser ?? "chrome";
-  const skipAutoInstall = options.skipAutoInstall ?? false;
+  const disableAutoLaunch = options.disableAutoLaunch ?? false;
   let outDir: string;
   let moduleRoot: string;
   let webExtRunner: any;
@@ -481,7 +481,7 @@ export default function browserExtension<T>(
 
       if (!isWatching) return;
 
-      if (!skipAutoInstall) {
+      if (!disableAutoLaunch) {
         if (webExtRunner == null) {
           const config = {
             target:


### PR DESCRIPTION
The auto-launching behavior can be undesirable in many circumstances like:

- using alternative browsers like edge (my setup)
- using WSL (also my setup)

I've added a `skipAutoInstall` option to easily disable auto-installing and launching to deal with that :)