### PR TITLE
fix: permissions field is not required but `vite dev` requires

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -308,7 +308,7 @@ export default function browserExtension(
     transformAssets(additionalInputTypes, "assets");
 
     if (isDevServer) {
-      transformedManifest.permissions.push("http://localhost/*");
+      transformedManifest.permissions?.push("http://localhost/*");
       const CSP = "script-src 'self' http://localhost:3000; object-src 'self'";
       if (transformedManifest.content_security_policy != null) {
         // TODO: "merge" CSPs automatically

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -308,7 +308,8 @@ export default function browserExtension(
     transformAssets(additionalInputTypes, "assets");
 
     if (isDevServer) {
-      transformedManifest.permissions?.push("http://localhost/*");
+      transformedManifest.permissions ??= [];
+      transformedManifest.permissions.push("http://localhost/*");
       const CSP = "script-src 'self' http://localhost:3000; object-src 'self'";
       if (transformedManifest.content_security_policy != null) {
         // TODO: "merge" CSPs automatically


### PR DESCRIPTION
permissions fields is not required in manifest.json

See: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/permissions

but fail when run `vite dev` caused by undefined of
`transformedManifest.permissions` if unset permissions field in manifest.json

---

`pnpm build ` passed with `demos/{localization,vanilla,vue}`