### PR TITLE
feat(react): add tsx extension in scriptExtensions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -260,7 +260,7 @@ export default function browserExtension(
     };
 
     const htmlExtensions = [".html"];
-    const scriptExtensions = [".ts", ".js"];
+    const scriptExtensions = [".ts", ".js", ".tsx"];
     const additionalInputTypes = options.additionalInputs?.reduce(
       (mapping, input) => {
         if (htmlExtensions.find((ext) => input.endsWith(ext))) {


### PR DESCRIPTION
## Problem
I try to add the react content script application in my manifest.json but when I add the reference to the .tsx file this does not work.

## Solution
The solution I have found is to inject my content-script from the background script. 
I have added .tsx to scriptExtensions so that tsx files included in additionalInputs are treated as scripts.

- Config:
`
  additionalInputs: [
        'content-scripts/index.tsx'
      ]
`
- Build output without tsx in scriptExtension:
`
/dist/content-scripts.index.html
`
- Build output with tsx in scriptExtension:
`
/dist/content-scripts.index.js
`
If someone has an approach to use the tsx from the manifest.json I think it would be good to add it to support both in additionalInputs and in the manifest.json a react application.
