### PR TITLE
Change to ES Modules format (as Dual ESM/CJS package)

### DIFF
--- a/lib/decs.d.ts
+++ b/lib/decs.d.ts
@@ -1,0 +1,1 @@
+declare module "web-ext";

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -17,7 +17,7 @@ import {
   mkdirSync,
   existsSync,
 } from "fs";
-const webExt = require("web-ext");
+import webExt from "web-ext";
 import { buildScript, BuildScriptConfig } from "./src/build-script";
 import { resolveBrowserTagsInObject } from "./src/resolve-browser-flags";
 import { validateManifest } from "./src/validation";

--- a/lib/package.json
+++ b/lib/package.json
@@ -6,6 +6,7 @@
   "repository": {
     "url": "https://github.com/aklinker1/vite-plugin-web-extension"
   },
+  "type": "module",
   "keywords": [
     "vite-plugin",
     "web",
@@ -19,16 +20,22 @@
     "addon",
     "browser"
   ],
-  "main": "dist/index.js",
+  "exports": {
+    "import": "./dist/index.js",
+    "require": "./dist/index.cjs"
+  },
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
+    "dist/index.cjs",
     "dist/index.js",
     "dist/index.d.ts",
     "index.ts"
   ],
   "scripts": {
     "compile": "tsc",
-    "build": "tsup index.ts && tsc",
+    "build": "tsup --format esm,cjs index.ts && tsc",
     "prepare": "pnpm build"
   },
   "dependencies": {


### PR DESCRIPTION
Hi,
I had trouble with `import webExtension from 'vite-plugin-web-extension'` in my 'vite.config.ts' from my TypeScript project which has `"type": "module"` set in `package.json`. The problem was with the default import of a function (`TypeError: webExtension is not a function`). It may have been due to my TypeScript configuration but I did not manage to find a working configuration. `webExtension` was being set to an object with properties `default` and `readJsonFile` rather than to just the default export as expected.

I managed to fix this in my fork by changing the `lib` package to a [Dual CommonJS/ES module package](https://nodejs.org/api/packages.html#dual-commonjses-module-packages), using [Approach #2: Isolate state](https://nodejs.org/api/packages.html#approach-2-isolate-state). Unless I am mistaken, this feature is supported on Node 14, which you are already targeting. I don't think the dual package hazard should be a problem as the package is not stateful, I believe?

So now `tsup` builds both CJS ('dist/index.cjs') and ESM ('dist/index.js'). The lib package has `"type": "module"` set so that it is ESM by default.
I have not had any issues yet in my ESM project. The demos all build correctly (I have not changed them to` "type": "module"`, so they should be using 'vite-plugin-web-extension' in CJS mode, the same way it always was). I could add an ESM demo too if you want (e.g. just copy vanilla but change to `"type": "module"`).
I could not get the test in tests directory to run.

It seems to work but the ESM/CJS situation in Node is really complicated at the moment and I am not completely confident that my changes won't break things for someone. However, I expect others will run in to the same problem I had using similar setups (ESM, TypeScript) since ESM is becoming more common in the Node ecosystem. If I have set up the dual module correctly, the CJS should work the same way it always did for packages still on CJS.