### PR TITLE
fix: ignore `vite.config.ts` files for internal builds

### DIFF
--- a/packages/vite-plugin-web-extension/src/build-script.ts
+++ b/packages/vite-plugin-web-extension/src/build-script.ts
@@ -73,5 +73,5 @@ export async function buildScript(
     libModeViteConfig ?? {}
   );
   log("Final config:", inspect(buildConfig));
-  await Vite.build(buildConfig);
+  await Vite.build({ ...buildConfig, configFile: false });
 }


### PR DESCRIPTION
These internal builds already inherit the root vite config file's configuration, it is passed down through the extension.

So all we need to do is tell vite to not discover any config files, and the recursion will break.

This closes #56 (the infinite loop half of the issue).