### PR TITLE
fix: Open browser with absolute path to extension

### DIFF
--- a/packages/vite-plugin-web-extension/index.ts
+++ b/packages/vite-plugin-web-extension/index.ts
@@ -426,7 +426,7 @@ export default function browserExtension(
             : "chromium",
         ...options.webExtConfig,
         // No touch - can't exit the terminal if these are changed, so they cannot be overridden
-        sourceDir: outDir,
+        sourceDir: path.resolve(process.cwd(), outDir),
         noReload: false,
         noInput: true,
       };


### PR DESCRIPTION
This closes #63 

On windows, if you run `web-ext` with a relative path like `"dist"` instead of `"C:\Path\to\dist"`, it will try and install the chrome extension relative to your chrome install directory. So we just need to pass in a absolute path.