### PR TITLE
fix: Use correct origin for assets in dev mode

### DIFF
--- a/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
@@ -50,6 +50,7 @@ export function hmrRewritePlugin(config: {
 
       const hmrConfig: InlineConfig = {
         server: {
+          origin: "http://127.0.0.1:5173",
           hmr: {
             protocol: "http:",
             host: "127.0.0.1",

--- a/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
@@ -50,7 +50,6 @@ export function hmrRewritePlugin(config: {
 
       const hmrConfig: InlineConfig = {
         server: {
-          origin: "http://127.0.0.1:5173",
           hmr: {
             protocol: "http:",
             host: "127.0.0.1",

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -112,8 +112,8 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
       return vite.mergeConfig(
         {
           server: {
-            // Set the server origin so assets contain the entire url, not just the absolute path
-            // See #79
+            // Set the server origin so assets contain the entire url in dev mode, not just the
+            // absolute path. See #79
             origin: "http://127.0.0.1:5173",
           },
           build: {

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -111,6 +111,9 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
 
       return vite.mergeConfig(
         {
+          server: {
+            origin: "http://127.0.0.1:5173",
+          },
           build: {
             // Since this plugin schedules multiple builds, we can't let any of the builds empty the
             // outDir. Instead, the plugin cleans up the outDir manually in `onBuildStart`

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -112,6 +112,8 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
       return vite.mergeConfig(
         {
           server: {
+            // Set the server origin so assets contain the entire url, not just the absolute path
+            // See #79
             origin: "http://127.0.0.1:5173",
           },
           build: {


### PR DESCRIPTION
This closes #79 

For this component:

<img width="423" alt="Screen Shot 2023-03-09 at 12 06 17 PM" src="https://user-images.githubusercontent.com/10101283/224116609-ce41ec0d-6f5c-4b85-9a7f-b417363525f7.png">

The `src` attribute has the full URL instead of just the absolute path.

<img width="404" alt="Screen Shot 2023-03-09 at 12 06 06 PM" src="https://user-images.githubusercontent.com/10101283/224116615-26684c64-5010-4552-ad1d-c2e972bb7462.png">

> Vite logs a warning that I'm importing a asset from the public directory, but it still proves the fix works.