### PR TITLE
chore: Add svelte template to starter kit

### DIFF
--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -50,6 +50,7 @@ There are several starter templates to choose from:
 | `vanilla-js` | `vanilla-ts` |
 |   `vue-js`   |   `vue-ts`   |
 |  `react-js`  |  `react-ts`  |
+|  `svelte-js` |  `svelte-ts` |
 
 :::
 

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/jsconfig.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/jsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "Node",
+    "target": "ESNext",
+    "module": "ESNext",
+    /**
+     * svelte-preprocess cannot figure out whether you have
+     * a value or a type, so tell TypeScript to enforce using
+     * `import type` instead of `import` for Types.
+     */
+    "importsNotUsedAsValues": "error",
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    /**
+     * To have warnings / errors of the Svelte compiler at the
+     * correct position, enable source maps by default.
+     */
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    /**
+     * Typecheck JS in `.svelte` and `.js` files by default.
+     * Disable this if you'd like to use dynamic types.
+     */
+    "checkJs": true
+  },
+  /**
+   * Use global.d.ts instead of compilerOptions.types
+   * to avoid limiting type declarations.
+   */
+  "include": ["src/**/*.d.ts", "src/**/*.js", "src/**/*.svelte"]
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "${{ template.projectName }}",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.0.3",
+    "svelte": "^3.55.1",
+    "vite": "^4.1.4",
+    "vite-plugin-web-extension": "^3.0.1",
+    "webextension-polyfill": "^0.10.0"
+  }
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/background.js
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/background.js
@@ -1,0 +1,7 @@
+import browser from "webextension-polyfill";
+
+console.log("Hello from the background!");
+
+browser.runtime.onInstalled.addListener((details) => {
+  console.log("Extension installed:", details);
+});

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/manifest.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/manifest.json
@@ -1,0 +1,21 @@
+{
+  "{{chrome}}.manifest_version": 3,
+  "{{firefox}}.manifest_version": 2,
+  "icons": {
+    "16": "icon/16.png",
+    "32": "icon/32.png",
+    "48": "icon/48.png",
+    "96": "icon/96.png",
+    "128": "icon/128.png"
+  },
+  "{{chrome}}.action": {
+    "default_popup": "src/popup.html"
+  },
+  "{{firefox}}.browser_action": {
+    "default_popup": "src/popup.html"
+  },
+  "background": {
+    "{{chrome}}.service_worker": "src/background.js",
+    "{{firefox}}.scripts": ["src/background.js"]
+  }
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/pages/Popup.svelte
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/pages/Popup.svelte
@@ -1,4 +1,4 @@
-<script lang="ts">
+<script>
   console.log("Hello from the popup!");
 </script>
 

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.css
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.css
@@ -1,0 +1,45 @@
+html,
+body {
+  width: 300px;
+  height: 400px;
+  padding: 0;
+  margin: 0;
+}
+
+body {
+  background-color: rgb(36, 36, 36);
+}
+
+body > div {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+}
+
+img {
+  width: 200px;
+  height: 200px;
+}
+
+h1 {
+  font-size: 18px;
+  color: white;
+  font-weight: bold;
+  margin: 0;
+}
+
+p {
+  color: white;
+  opacity: 0.7;
+  margin: 0;
+}
+
+code {
+  font-size: 12px;
+  padding: 2px 4px;
+  background-color: #ffffff24;
+  border-radius: 2px;
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.html
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./popup.css" />
+    <title>Popup</title>
+  </head>
+
+  <body></body>
+
+  <script type="module" src="./popup.js"></script>
+</html>

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.js
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.js
@@ -1,0 +1,3 @@
+import Popup from './pages/Popup.svelte'
+
+new Popup({ target: document.body });

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/vite.env.d.ts
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/vite.env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/svelte.config.js
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/vite.config.js
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/vite.config.js
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import webExtension, { readJsonFile } from "vite-plugin-web-extension";
+
+function generateManifest() {
+  const manifest = readJsonFile("src/manifest.json");
+  const pkg = readJsonFile("package.json");
+  return {
+    name: pkg.name,
+    description: pkg.description,
+    version: pkg.version,
+    ...manifest,
+  };
+}
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    svelte(),
+    webExtension({
+      manifest: generateManifest,
+      watchFilePaths: ["package.json", "manifest.json"],
+    }),
+  ],
+});

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "${{ template.projectName }}",
+  "private": true,
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "check": "svelte-check --tsconfig ./tsconfig.json"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^2.0.3",
+    "@tsconfig/svelte": "^3.0.0",
+    "@types/webextension-polyfill": "^0.10.0",
+    "svelte": "^3.55.1",
+    "svelte-check": "^2.10.3",
+    "tslib": "^2.5.0",
+    "typescript": "^4.9.3",
+    "vite": "^4.1.4",
+    "vite-plugin-web-extension": "^3.0.1",
+    "webextension-polyfill": "^0.10.0"
+  }
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/background.ts
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/background.ts
@@ -1,0 +1,7 @@
+import browser from "webextension-polyfill";
+
+console.log("Hello from the background!");
+
+browser.runtime.onInstalled.addListener((details) => {
+  console.log("Extension installed:", details);
+});

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/manifest.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/manifest.json
@@ -1,0 +1,21 @@
+{
+  "{{chrome}}.manifest_version": 3,
+  "{{firefox}}.manifest_version": 2,
+  "icons": {
+    "16": "icon/16.png",
+    "32": "icon/32.png",
+    "48": "icon/48.png",
+    "96": "icon/96.png",
+    "128": "icon/128.png"
+  },
+  "{{chrome}}.action": {
+    "default_popup": "src/popup.html"
+  },
+  "{{firefox}}.browser_action": {
+    "default_popup": "src/popup.html"
+  },
+  "background": {
+    "{{chrome}}.service_worker": "src/background.ts",
+    "{{firefox}}.scripts": ["src/background.ts"]
+  }
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/pages/Popup.svelte
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/pages/Popup.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  console.log("Hellow from the popup!");
+  let template = ${{ template.templateName }};
+</script>
+
+<div>
+  <img src="/icon-with-shadow.svg" />
+  <h1>vite-plugin-web-extension</h1>
+  <p>
+    Template: <code>{template}</code>
+  </p>
+</div>
+
+<style>
+
+</style>

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/pages/Popup.svelte
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/pages/Popup.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
   console.log("Hellow from the popup!");
-  let template = ${{ template.templateName }};
 </script>
 
 <div>
   <img src="/icon-with-shadow.svg" />
   <h1>vite-plugin-web-extension</h1>
   <p>
-    Template: <code>{template}</code>
+    Template: <code>${{ template.templateName }}</code>
   </p>
 </div>
 

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.css
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.css
@@ -1,0 +1,45 @@
+html,
+body {
+  width: 300px;
+  height: 400px;
+  padding: 0;
+  margin: 0;
+}
+
+body {
+  background-color: rgb(36, 36, 36);
+}
+
+body > div {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: center;
+  justify-content: center;
+}
+
+img {
+  width: 200px;
+  height: 200px;
+}
+
+h1 {
+  font-size: 18px;
+  color: white;
+  font-weight: bold;
+  margin: 0;
+}
+
+p {
+  color: white;
+  opacity: 0.7;
+  margin: 0;
+}
+
+code {
+  font-size: 12px;
+  padding: 2px 4px;
+  background-color: #ffffff24;
+  border-radius: 2px;
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.html
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="./popup.css" />
+    <title>Popup</title>
+  </head>
+
+  <body></body>
+
+  <script type="module" src="./popup.ts"></script>
+</html>

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.ts
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.ts
@@ -1,0 +1,3 @@
+import Popup from './pages/Popup.svelte'
+
+new Popup({ target: document.body });

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/vite.env.d.ts
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/vite.env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="svelte" />
+/// <reference types="vite/client" />

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/svelte.config.js
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/svelte.config.js
@@ -1,0 +1,7 @@
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte'
+
+export default {
+  // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
+  // for more information about preprocessors
+  preprocess: vitePreprocess(),
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/tsconfig.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "allowJs": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.svelte"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/tsconfig.node.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/vite.config.ts
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/vite.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from "vite";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import webExtension, { readJsonFile } from "vite-plugin-web-extension";
+
+function generateManifest() {
+  const manifest = readJsonFile("src/manifest.json");
+  const pkg = readJsonFile("package.json");
+  return {
+    name: pkg.name,
+    description: pkg.description,
+    version: pkg.version,
+    ...manifest,
+  };
+}
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  plugins: [
+    svelte(),
+    webExtension({
+      manifest: generateManifest,
+      watchFilePaths: ["package.json", "manifest.json"],
+    }),
+  ],
+});

--- a/packages/create-vite-plugin-web-extension/templates/templates.json
+++ b/packages/create-vite-plugin-web-extension/templates/templates.json
@@ -1,1 +1,1 @@
-["vanilla-js", "vanilla-ts", "vue-js", "vue-ts", "react-js", "react-ts"]
+["vanilla-js", "vanilla-ts", "vue-js", "vue-ts", "react-js", "react-ts", "svelte-js", "svelte-ts"]

--- a/packages/create-vite-plugin-web-extension/test-all.sh
+++ b/packages/create-vite-plugin-web-extension/test-all.sh
@@ -10,6 +10,8 @@ TEMPLATES=(
   vue-ts
   react-js
   react-ts
+  svelte-js
+  svelte-ts
 )
 
 for TEMPLATE in "${TEMPLATES[@]}"; do


### PR DESCRIPTION
This PR adresses #86.

I’ve adhered as much as possible to the current templates regarding the structure and some minor criteria (import css in the html file, don't export the app in the entrypoint, etc).

It is mostly based on Vite's Svelte, although I modified the `tsconfig.json` a bit to conform to the rest.
It also includes, as per Vite's default, a jsconfig for the js only file, which enables IDE typechecking.

You can test it by cloning the `add-svelte-template-test` branch.

I've ran the `test-all.sh` using `gitbash` and it looked fine. I only ran into trouble with the vue-js/ts ones, which appeared blank, but that also happened on a freshly cloned repo, so I assume that's something else.

Please let me know if there's any issue. I've never worked on a monorepo before!

---

Also, I just noticed the version bump to `3.0.2`. Should I include that here for all the templates?
