### PR TITLE
fix: Define `process.env.NODE_ENV` for lib mode builds

### DIFF
--- a/packages/vite-plugin-web-extension/src/build/build-context.ts
+++ b/packages/vite-plugin-web-extension/src/build/build-context.ts
@@ -19,6 +19,7 @@ interface RebuildOptions {
   mode: BuildMode;
   server?: vite.ViteDevServer;
   onSuccess?: () => Promise<void> | void;
+  viteMode: string;
 }
 
 export interface BuildContext {
@@ -55,6 +56,7 @@ export function createBuildContext({
     server,
     onSuccess,
     mode,
+    viteMode,
   }: RebuildOptions) {
     const entryConfigs = getViteConfigsForInputs({
       paths,
@@ -67,6 +69,7 @@ export function createBuildContext({
       baseSandboxViteConfig: {},
       baseScriptViteConfig: pluginOptions.scriptViteConfig ?? {},
       baseOtherViteConfig: {},
+      viteMode,
     });
     const multibuildManager = createMultibuildCompleteManager(async () => {
       // This prints before the manifest plugin continues in watch mode

--- a/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
+++ b/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
@@ -78,6 +78,7 @@ export function getViteConfigsForInputs(options: {
   baseSandboxViteConfig: vite.InlineConfig;
   baseScriptViteConfig: vite.InlineConfig;
   baseOtherViteConfig: vite.InlineConfig;
+  viteMode: string;
 }): CombinedViteConfigs {
   const { paths, additionalInputs, manifest, mode, logger, server } = options;
   const configs = new CombinedViteConfigs();
@@ -170,6 +171,10 @@ export function getViteConfigsForInputs(options: {
           formats: ["iife"],
           fileName: () => moduleId + ".js",
         },
+      },
+      define: {
+        // https://vitejs.dev/guide/build.html#library-mode
+        "process.env.NODE_ENV": JSON.stringify(options.viteMode),
       },
     };
     return vite.mergeConfig(baseConfig, inputConfig);

--- a/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
+++ b/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
@@ -174,7 +174,7 @@ export function getViteConfigsForInputs(options: {
       },
       define: {
         // See https://github.com/aklinker1/vite-plugin-web-extension/issues/96
-        "process.env.NODE_ENV": JSON.stringify(options.viteMode),
+        "process.env.NODE_ENV": `"${options.viteMode}"`,
       },
     };
     return vite.mergeConfig(baseConfig, inputConfig);

--- a/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
+++ b/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
@@ -173,7 +173,7 @@ export function getViteConfigsForInputs(options: {
         },
       },
       define: {
-        // https://vitejs.dev/guide/build.html#library-mode
+        // See https://github.com/aklinker1/vite-plugin-web-extension/issues/96
         "process.env.NODE_ENV": JSON.stringify(options.viteMode),
       },
     };

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -112,6 +112,7 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
       manifest: manifestWithInputs,
       mode,
       server,
+      viteMode: resolvedConfig.mode,
       onSuccess: async () => {
         if (extensionRunner) await extensionRunner.reload();
       },


### PR DESCRIPTION
This closes #96.

I tried using other approaches than using library mode, but could not get anything else to work. So I stuck with library mode, and just defined a replacement for the `process.env.NODE_ENV` reference.