### PR TITLE
fix: Normalize input module IDs to fix HMR on Windows

### DIFF
--- a/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
@@ -39,7 +39,9 @@ export function hmrRewritePlugin(config: {
     name: HMR_REWRITE_PLUGIN_NAME,
 
     config(config) {
-      inputIds = Object.values(config.build?.rollupOptions?.input ?? {});
+      inputIds = Object.values(config.build?.rollupOptions?.input ?? {}).map(
+        (inputId) => vite.normalizePath(inputId)
+      );
 
       const hmrConfig: vite.InlineConfig = {
         server: {


### PR DESCRIPTION
This closes #107 