### PR TITLE
feat: Add `transformManifest` option

### DIFF
--- a/docs/config/plugin-options.md
+++ b/docs/config/plugin-options.md
@@ -118,6 +118,31 @@ Setting this to `true` skips the validation step.
 
 > The validation process downloads the schema from the given URL. If you are working offline, this step will automatically be skipped.
 
+## `transformManifest`
+
+Since [v3.1.0](https://github.com/aklinker1/vite-plugin-web-extension/releases/tag/v3.1.0)
+
+```ts
+transformManifest?: (manifest: WebExtensionManifest) => WebExtensionManifest | Promise<WebExtensionManifest>
+```
+
+A hook that lets you manipulate the manifest before it is written to the output directory by returning a new manifest.
+
+### Example
+
+Here, `transformManifest` is used to remove all the CSS files from the content scripts.
+
+```ts
+webExtension({
+  transformManifest(manifest) {
+    manifest.content_scripts.forEach((script) => {
+      delete script.css;
+    });
+    return manifest;
+  },
+});
+```
+
 ## `watchFilePaths`
 
 ```ts

--- a/packages/e2e/e2e.test.ts
+++ b/packages/e2e/e2e.test.ts
@@ -631,5 +631,75 @@ describe("Vite Plugin Web Extension", () => {
 
       await expect(build).rejects.toMatchSnapshot();
     });
+
+    it("should support transforming the manifest synchronously prior to output via transformManifest", async () => {
+      await expectBuildToMatchSnapshot(
+        {
+          root: "extension",
+          build: {
+            outDir: DIST_DIRECTORY,
+            emptyOutDir: true,
+          },
+          plugins: [
+            webExtension({
+              manifest: () =>
+                manifest({
+                  browser_action: {
+                    default_popup: "page1.html",
+                  },
+                }),
+              transformManifest: (manifest) => ({
+                name: 'Transform Added Name',
+                ...manifest
+              })
+            }),
+          ],
+        },
+        baseOutputs(["dist/page1.html"])
+      );
+      expectManifest(
+        manifest({
+          name: 'Transform Added Name',
+          browser_action: {
+            default_popup: "page1.html",
+          },
+        })
+      );
+    })
+
+    it("should support transforming the manifest asynchronously prior to output via transformManifest", async () => {
+      await expectBuildToMatchSnapshot(
+        {
+          root: "extension",
+          build: {
+            outDir: DIST_DIRECTORY,
+            emptyOutDir: true,
+          },
+          plugins: [
+            webExtension({
+              manifest: () =>
+                manifest({
+                  browser_action: {
+                    default_popup: "page1.html",
+                  },
+                }),
+              transformManifest: (manifest) => Promise.resolve({
+                name: 'Transform Added Name',
+                ...manifest
+              })
+            }),
+          ],
+        },
+        baseOutputs(["dist/page1.html"])
+      );
+      expectManifest(
+        manifest({
+          name: 'Transform Added Name',
+          browser_action: {
+            default_popup: "page1.html",
+          },
+        })
+      );
+    })
   });
 });

--- a/packages/vite-plugin-web-extension/src/options.ts
+++ b/packages/vite-plugin-web-extension/src/options.ts
@@ -1,4 +1,5 @@
 import * as vite from "vite";
+import type Browser from "webextension-polyfill";
 
 export type Manifest = any;
 
@@ -22,7 +23,11 @@ export interface UserOptions {
    * An optional transform function to modify the manifest just before the plugin writes
    * it to the output directory.
    */
-  transformManifest?: ((manifest: Manifest) => Manifest) | ((manifest: Manifest) => Promise<Manifest>);
+  transformManifest?: (
+    manifest: Browser.Manifest.WebExtensionManifest
+  ) =>
+    | Browser.Manifest.WebExtensionManifest
+    | Promise<Browser.Manifest.WebExtensionManifest>;
 
   /**
    * Used to include additional files, like content scripts, not mentioned in the final
@@ -88,7 +93,11 @@ export interface UserOptions {
  */
 export interface ResolvedOptions {
   manifest: string | (() => Manifest) | (() => Promise<Manifest>);
-  transformManifest?: ((manifest: Manifest) => Manifest) | ((manifest: Manifest) => Promise<Manifest>);
+  transformManifest?: (
+    manifest: Browser.Manifest.WebExtensionManifest
+  ) =>
+    | Browser.Manifest.WebExtensionManifest
+    | Promise<Browser.Manifest.WebExtensionManifest>;
   additionalInputs: string[];
   disableAutoLaunch: boolean;
   watchFilePaths: string[];

--- a/packages/vite-plugin-web-extension/src/options.ts
+++ b/packages/vite-plugin-web-extension/src/options.ts
@@ -19,6 +19,12 @@ export interface UserOptions {
   manifest?: string | (() => Manifest) | (() => Promise<Manifest>) | undefined;
 
   /**
+   * An optional transform function to modify the manifest just before the plugin writes
+   * it to the output directory.
+   */
+  transformManifest?: ((manifest: Manifest) => Manifest) | ((manifest: Manifest) => Promise<Manifest>);
+
+  /**
    * Used to include additional files, like content scripts, not mentioned in the final
    * `manifest.json`. Paths should be relative to Vite's `root` (or `process.cwd()` if not set)
    */
@@ -82,6 +88,7 @@ export interface UserOptions {
  */
 export interface ResolvedOptions {
   manifest: string | (() => Manifest) | (() => Promise<Manifest>);
+  transformManifest?: ((manifest: Manifest) => Manifest) | ((manifest: Manifest) => Promise<Manifest>);
   additionalInputs: string[];
   disableAutoLaunch: boolean;
   watchFilePaths: string[];

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -119,7 +119,11 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
     });
 
     // Generate the manifest based on the output files
-    const finalManifest = renderManifest(manifestWithInputs, ctx.getBundles());
+    const renderedManifest = renderManifest(manifestWithInputs, ctx.getBundles());
+
+    const finalManifest = options.transformManifest
+      ? await options.transformManifest(renderedManifest)
+      : renderedManifest;
 
     // Add permissions and CSP for the dev server
     if (mode === BuildMode.DEV) {


### PR DESCRIPTION
This adds a configuration option to allow projects to customize the manifest after rendering in the event changes are needed from the manifest which the plugin produces.

This resolves/is a result of the [discussion here](https://github.com/aklinker1/vite-plugin-web-extension/discussions/122).