### PR TITLE
fix: add `transformManifest` to `internalOptions`

### DIFF
--- a/packages/vite-plugin-web-extension/src/index.ts
+++ b/packages/vite-plugin-web-extension/src/index.ts
@@ -24,6 +24,7 @@ export default function webExtension(
     browser: options.browser,
     htmlViteConfig: options.htmlViteConfig,
     scriptViteConfig: options.scriptViteConfig,
+    transformManifest: options.transformManifest,
     webExtConfig: options.webExtConfig,
     verbose: process.argv.includes("-d") || process.argv.includes("--debug"),
     disableColors:


### PR DESCRIPTION
Last PR missed adding `transformManifest` to the `internalOptions`.