### PR TITLE
feat: Don't transform entrypoints prefixed with `public:`

### DIFF
--- a/packages/vite-plugin-web-extension/package.json
+++ b/packages/vite-plugin-web-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-web-extension",
-  "version": "4.1.0-alpha1",
+  "version": "4.1.0-alpha2",
   "license": "MIT",
   "homepage": "https://vite-plugin-web-extension.aklinker1.io",
   "repository": {

--- a/packages/vite-plugin-web-extension/package.json
+++ b/packages/vite-plugin-web-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-web-extension",
-  "version": "4.1.0-alpha2",
+  "version": "4.0.1",
   "license": "MIT",
   "homepage": "https://vite-plugin-web-extension.aklinker1.io",
   "repository": {

--- a/packages/vite-plugin-web-extension/package.json
+++ b/packages/vite-plugin-web-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-web-extension",
-  "version": "4.0.1",
+  "version": "4.1.0-alpha1",
   "license": "MIT",
   "homepage": "https://vite-plugin-web-extension.aklinker1.io",
   "repository": {

--- a/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
+++ b/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
@@ -305,8 +305,8 @@ function separateAdditionalInputs(additionalInputs: string[]) {
 function simplifyEntriesList(
   a: Array<string | string[] | undefined> | undefined
 ): string[] {
-  return compact<string>(a?.flat() ?? []).filter((a) =>
-    a.startsWith("public:")
+  return compact<string>(a?.flat() ?? []).filter(
+    (a) => !a.startsWith("public:")
   );
 }
 

--- a/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
+++ b/packages/vite-plugin-web-extension/src/build/getViteConfigsForInputs.ts
@@ -300,12 +300,14 @@ function separateAdditionalInputs(additionalInputs: string[]) {
 
 /**
  * Take in a list of any combination of single entries, lists of entries, or undefined and return a
- * single, simple list of all the truthy entry-points.
+ * single, simple list of all the truthy, non-public, entry-points
  */
 function simplifyEntriesList(
   a: Array<string | string[] | undefined> | undefined
 ): string[] {
-  return compact<string>(a?.flat() ?? []);
+  return compact<string>(a?.flat() ?? []).filter((a) =>
+    a.startsWith("public:")
+  );
 }
 
 function validateCombinedViteConfigs(configs: CombinedViteConfigs) {

--- a/packages/vite-plugin-web-extension/src/build/renderManifest.test.ts
+++ b/packages/vite-plugin-web-extension/src/build/renderManifest.test.ts
@@ -169,4 +169,26 @@ describe("renderManifest", () => {
 
     expect(actual).toEqual(expected);
   });
+
+  it("should not transform 'public:' prefixed paths", () => {
+    const input = {
+      name: "mv2-html-test",
+      version: "1.0.0",
+      browser_action: {
+        default_popup: "public:popup.html",
+      },
+    };
+    const bundles: BundleMap = {};
+    const expected = {
+      name: "mv2-html-test",
+      version: "1.0.0",
+      browser_action: {
+        default_popup: "popup.html",
+      },
+    };
+
+    const actual = renderManifest(input, bundles);
+
+    expect(actual).toEqual(expected);
+  });
 });

--- a/packages/vite-plugin-web-extension/src/build/renderManifest.ts
+++ b/packages/vite-plugin-web-extension/src/build/renderManifest.ts
@@ -81,11 +81,16 @@ function replaceEntrypoint<T>(
   const entry = parent?.[key] as string | undefined;
   if (entry == null) return;
 
-  const { replacement, generatedFiles } = findReplacement(entry, bundles);
-  // @ts-expect-error
-  parent[key] = replacement;
+  if (entry.startsWith("public:")) {
+    // @ts-expect-error
+    parent[key] = entry.replace("public:", "");
+  } else {
+    const { replacement, generatedFiles } = findReplacement(entry, bundles);
+    // @ts-expect-error
+    parent[key] = replacement;
 
-  if (onGeneratedFile) generatedFiles.forEach(onGeneratedFile);
+    if (onGeneratedFile) generatedFiles.forEach(onGeneratedFile);
+  }
 }
 
 function replaceEntrypointArray<T>(


### PR DESCRIPTION
This closes #167. If you add `public:` in front of an entrypoint in your manifest, the plugin will render it to the final manifest without processing the file.

For example, if you want to load jquery into a content script, and have downloaded a version locally:

```
public/
  vendor/
    jquery.min.js
src/
  my/
    content-script.ts
```

```jsonc
{
  // ...
  "content_scripts": [
    {
      "matches": [...],
      "js": ["public:vendor/jquery.min.js", "src/my/content-script.ts"],
    }
  ]
}
```

If possible, I would recommend just using the NPM modules, but sometimes it's easier to just keep using a version from a CDN.