### PR TITLE
fix: Vite 5 HMR not working

### DIFF
--- a/packages/vite-plugin-web-extension/package.json
+++ b/packages/vite-plugin-web-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-web-extension",
-  "version": "4.1.1-alpha1",
+  "version": "4.1.0",
   "license": "MIT",
   "homepage": "https://vite-plugin-web-extension.aklinker1.io",
   "repository": {

--- a/packages/vite-plugin-web-extension/package.json
+++ b/packages/vite-plugin-web-extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-web-extension",
-  "version": "4.1.0",
+  "version": "4.1.1-alpha1",
   "license": "MIT",
   "homepage": "https://vite-plugin-web-extension.aklinker1.io",
   "repository": {

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -275,9 +275,17 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
       noInput.cleanupBundle(bundle);
     },
 
-    // Runs during: watch
+    // Runs during: watch, dev
     async watchChange(id) {
-      if (!browserOpened || id.startsWith(paths.outDir)) return;
+      if (
+        // Only run this hook for `vite build --watch`, not `vite dev`
+        mode === BuildMode.DEV ||
+        // Don't reload if the browser isn't opened yet
+        !browserOpened ||
+        // Don't reload if the change was a file written to the output directory
+        id.startsWith(paths.outDir)
+      )
+        return;
 
       const relativePath = path.relative(paths.rootDir, id);
       logger.log(


### PR DESCRIPTION
Vite started calling a hook in dev mode that it wasn't calling before in v5. Released v4.1.1-alpha1 for testing, confirmed that it fixes #172.