### PR TITLE
FIX - createManifestValidator failing because schemastore.org is returning 503

### DIFF
--- a/packages/vite-plugin-web-extension/src/manifest-validation.ts
+++ b/packages/vite-plugin-web-extension/src/manifest-validation.ts
@@ -5,7 +5,7 @@ import { inspect } from "node:util";
 import Ajv from "ajv";
 import { withTimeout } from "./utils";
 
-const SCHEMA_URL = new URL("https://json.schemastore.org/chrome-manifest");
+const SCHEMA_URL = new URL("https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/chrome-manifest.json");
 
 export type ValidateManifest = (manifest: any | undefined) => Promise<void>;
 


### PR DESCRIPTION
In the last two days builds time out due to the issue with the website  `https://json.schemastore.org`. 


I propose updating the SCHEMA_URL from its current `https://json.schemastore.org/chrome-manifest` URL to the raw GitHub content URL  `https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/chrome-manifest.json`. GitHub has superior availability and it's a smaller change that we will encounter this issue again. 

```
...
vite v5.1.0 building for development...
✓ 1 modules transformed.
dist/src/index.css  26.42 kB │ gzip: 4.85 kB
✓ built in 186ms
undefined:1
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN""http://www.w3.org/TR/html4/strict.dtd">
^

SyntaxError: Unexpected token '<', "<!DOCTYPE "... is not valid JSON
    at JSON.parse (<anonymous>)
    at IncomingMessage.<anonymous> (file:///path/to/project/node_modules/.pnpm/vite-plugin-web-extension@4.1.1/node_modules/vite-plugin-web-extension/dist/index.js:949:20)
    at IncomingMessage.emit (node:events:530:35)
    at endReadableNT (node:internal/streams/readable:1696:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)

Node.js v20.11.0
```

Fixes #182 .