### PR TITLE
fix: Changed react plugin to non-swc variation

### DIFF
--- a/packages/create-vite-plugin-web-extension/templates/react-js/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/react-js/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react": "^4.2.1",
     "vite": "^5.0.0",
     "vite-plugin-web-extension": "^4.0.0",
     "webextension-polyfill": "^0.10.0"

--- a/packages/create-vite-plugin-web-extension/templates/react-js/vite.config.js
+++ b/packages/create-vite-plugin-web-extension/templates/react-js/vite.config.js
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import webExtension, { readJsonFile } from "vite-plugin-web-extension";
-import path from "node:path";
 
 function generateManifest() {
   const manifest = readJsonFile("src/manifest.json");
@@ -22,12 +21,4 @@ export default defineConfig({
       manifest: generateManifest,
     }),
   ],
-  resolve: {
-    alias: {
-      // In dev mode, make sure fast refresh works
-      "/@react-refresh": path.resolve(
-        "node_modules/@vitejs/plugin-react-swc/refresh-runtime.js"
-      ),
-    },
-  },
 });

--- a/packages/create-vite-plugin-web-extension/templates/react-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/react-ts/package.json
@@ -15,7 +15,7 @@
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.9",
     "@types/webextension-polyfill": "^0.10.0",
-    "@vitejs/plugin-react-swc": "^3.5.0",
+    "@vitejs/plugin-react": "^4.2.1",
     "typescript": "^5.3.2",
     "vite": "^5.0.0",
     "vite-plugin-web-extension": "^4.0.0",

--- a/packages/create-vite-plugin-web-extension/templates/react-ts/vite.config.ts
+++ b/packages/create-vite-plugin-web-extension/templates/react-ts/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react-swc";
+import react from "@vitejs/plugin-react";
 import webExtension, { readJsonFile } from "vite-plugin-web-extension";
-import path from "node:path";
 
 function generateManifest() {
   const manifest = readJsonFile("src/manifest.json");
@@ -22,12 +21,4 @@ export default defineConfig({
       manifest: generateManifest,
     }),
   ],
-  resolve: {
-    alias: {
-      // In dev mode, make sure fast refresh works
-      "/@react-refresh": path.resolve(
-        "node_modules/@vitejs/plugin-react-swc/refresh-runtime.js"
-      ),
-    },
-  },
 });


### PR DESCRIPTION
This pull request is a hot-fix for the issues presented here:
https://github.com/aklinker1/vite-plugin-web-extension/issues/177

This isn't meant to be a permanent fix, but the defaults should just work out of the box until a the actual resolution is found for https://github.com/vitejs/vite-plugin-react-swc.