### PR TITLE
Update serializeDefine implementation from upstream vite

### DIFF
--- a/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/hmr-rewrite-plugin.ts
@@ -24,15 +24,24 @@ export function hmrRewritePlugin(config: {
       : undefined;
 
   // Coped from node_modules/vite, do a global search for: vite:client-inject
-  function serializeDefine(define: any): string {
+  function serializeDefine(define: Record<string, any>): string {
     let res = `{`;
-    for (const key in define) {
+    const keys = Object.keys(define);
+    for (let i = 0; i < keys.length; i++) {
+      const key = keys[i];
       const val = define[key];
-      res += `${JSON.stringify(key)}: ${
-        typeof val === "string" ? `(${val})` : JSON.stringify(val)
-      }, `;
+      res += `${JSON.stringify(key)}: ${handleDefineValue(val)}`;
+      if (i !== keys.length - 1) {
+        res += `, `;
+      }
     }
     return res + `}`;
+  }
+
+  function handleDefineValue(value: any): string {
+    if (typeof value === "undefined") return "undefined";
+    if (typeof value === "string") return value;
+    return JSON.stringify(value);
   }
 
   return {


### PR DESCRIPTION
This PR updates serializeDefine to latest version from vite. It fixes compilation errors when define contains string values. 

```
[vite:define] Transform failed with 1 error:
error: Invalid define value (must be an entity name or valid JSON syntax)
```

For some unknown reasons it's not working only in combination with @vitejs/plugin-react, however, the issue is with `(${val})` syntax, that esbuild doesn't accept.

### Environment

```
node@18.18.2
vite@^5.2.12
vite-plugin-web-extension@4.1.3
@vitejs/plugin-react@^4.3.0
```

### Sample config

```ts
export default defineConfig({
  define: {
    "process.env.REACT_APP_BASEURL": '""'
  },
  plugins: [
    react(),
    webExtension({
      manifest: generateManifest,
    }),
  ]
})
```