### PR TITLE
Refactored so that logging shows final config being sent to web-ext-run

### DIFF
--- a/packages/vite-plugin-web-extension/src/extension-runner/web-ext-runner.ts
+++ b/packages/vite-plugin-web-extension/src/extension-runner/web-ext-runner.ts
@@ -25,24 +25,26 @@ export function createWebExtRunner(
         if (level >= WARN_LOG_LEVEL) logger.warn(msg);
       };
 
-      const config = await loadConfig({ pluginOptions, logger, paths });
-      logger.verbose("web-ext config:" + inspect(config));
+      const initialConfig = await loadConfig({ pluginOptions, logger, paths });
       const target =
         pluginOptions.browser === null || pluginOptions.browser === "firefox"
           ? null
           : "chromium";
 
       const sourceDir = paths.outDir;
+      const config = {
+        ...initialConfig,
+        target,
+        sourceDir,
+        // The plugin handles reloads, so disable auto-reload behaviors in web-ext
+        noReload: true,
+        noInput: true,
+      }
+      logger.verbose("web-ext config:" + inspect(config));
+
 
       runner = await webExt.cmd.run(
-        {
-          ...config,
-          target,
-          sourceDir,
-          // The plugin handles reloads, so disable auto-reload behaviors in web-ext
-          noReload: true,
-          noInput: true,
-        },
+        config,
         {
           // Don't call `process.exit(0)` after starting web-ext
           shouldExitProgram: false,


### PR DESCRIPTION
I spent a considerable amount of time diagnosing why I wasn't getting expected results from web-ext using this project.  After reviewing the source, I discovered that the options I had configured were being overwritten by the code before being passed to web-ext.  

This change suggestion moves the feedback down below when the final changes are made to the config, so that the verbose logging showing what's being sent is accurate.