### PR TITLE
feat: Added `bundleInfoJsonPath` plugin option

### DIFF
--- a/docs/config/plugin-options.md
+++ b/docs/config/plugin-options.md
@@ -160,3 +160,11 @@ webExtConfig?: any
 ```
 
 This option allows you to pass configuration into `web-ext` when launching the browser. For more details, refer to [Browser Startup Configuration](/guide/configure-browser-startup.md).
+
+## `bundleInfoJsonPath`
+
+```ts
+bundleInfoJsonPath?: string
+```
+
+If set, the plugin will write a JSON file containing information about the built bundles to the specified path in the output directory. This can for example be useful for dynamically injecting content scripts/styles from background scripts.

--- a/packages/vite-plugin-web-extension/src/index.ts
+++ b/packages/vite-plugin-web-extension/src/index.ts
@@ -26,6 +26,7 @@ export default function webExtension(
     scriptViteConfig: options.scriptViteConfig,
     transformManifest: options.transformManifest,
     webExtConfig: options.webExtConfig,
+    bundleInfoJsonPath: options.bundleInfoJsonPath,
     verbose: process.argv.includes("-d") || process.argv.includes("--debug"),
     disableColors:
       process.env.CI === "true" || process.env.DISABLE_COLORS === "true", // TODO: document env var

--- a/packages/vite-plugin-web-extension/src/options.ts
+++ b/packages/vite-plugin-web-extension/src/options.ts
@@ -86,6 +86,11 @@ export interface UserOptions {
    * <https://github.com/mozilla/web-ext/blob/666886f40a967b515d43cf38fc9aec67ad744d89/src/program.js#L559>.
    */
   webExtConfig?: any;
+
+  /**
+   * Output path to a JSON file containing information about the generated bundles.
+   */
+  bundleInfoJsonPath?: string;
 }
 
 /**
@@ -109,6 +114,7 @@ export interface ResolvedOptions {
   verbose: boolean;
   disableColors: boolean;
   webExtConfig?: any;
+  bundleInfoJsonPath?: string;
 }
 
 /**

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -145,6 +145,14 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
       name: "manifest.json",
     });
 
+    if (options.bundleInfoJsonPath) {
+      emitFile({
+        type: "asset",
+        source: JSON.stringify(ctx.getBundles()),
+        fileName: options.bundleInfoJsonPath,
+      });
+    }
+
     await copyPublicDirToOutDir({ mode, paths });
 
     // In dev mode, open up the browser immediately after the build context is finished with the


### PR DESCRIPTION
This PR adds the following plugin option:

```ts
bundleInfoJsonPath?: string
```

If set, the plugin will write a JSON file containing information about the built bundles to the specified path in the output directory. This can for example be useful for dynamically injecting content scripts/styles from background scripts.
