### PR TITLE
chore: migrate svelte to v5 release

### DIFF
--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/package.json
@@ -8,9 +8,9 @@
     "build": "vite build"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.1",
-    "svelte": "^4.2.18",
-    "vite": "^5.3.1",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
+    "svelte": "^5.0.0",
+    "vite": "^5.4.4",
     "vite-plugin-web-extension": "^4.1.6",
     "webextension-polyfill": "^0.10.0"
   }

--- a/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.js
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-js/src/popup.js
@@ -1,3 +1,4 @@
 import Popup from './pages/Popup.svelte'
+import { mount } from "svelte";
 
-new Popup({ target: document.body });
+mount(Popup, { target: document.body });

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/package.json
@@ -9,14 +9,14 @@
     "check": "svelte-check --tsconfig ./tsconfig.json"
   },
   "devDependencies": {
-    "@sveltejs/vite-plugin-svelte": "^3.1.1",
+    "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tsconfig/svelte": "^5.0.4",
     "@types/webextension-polyfill": "^0.10.0",
-    "svelte": "^4.2.18",
-    "svelte-check": "^3.8.1",
+    "svelte": "^5.0.0",
+    "svelte-check": "^4.0.0",
     "tslib": "^2.6.3",
-    "typescript": "^5.3.2",
-    "vite": "^5.3.1",
+    "typescript": "^5.5.0",
+    "vite": "^5.4.4",
     "vite-plugin-web-extension": "^4.1.6",
     "webextension-polyfill": "^0.10.0"
   }

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.ts
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/src/popup.ts
@@ -1,3 +1,4 @@
 import Popup from './pages/Popup.svelte'
+import { mount } from "svelte";
 
-new Popup({ target: document.body });
+mount(Popup, { target: document.body });


### PR DESCRIPTION
This migrates both svelte templates to svelte v5 release. It might fix #215