### PR TITLE
chore: Use tilde for typescript versions in templates

### DIFF
--- a/packages/create-vite-plugin-web-extension/templates/react-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/react-ts/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "^18.0.9",
     "@types/webextension-polyfill": "^0.10.0",
     "@vitejs/plugin-react": "^4.2.1",
-    "typescript": "^5.3.2",
+    "typescript": "~5.6.3",
     "vite": "^5.0.0",
     "vite-plugin-web-extension": "^4.0.0",
     "webextension-polyfill": "^0.10.0"

--- a/packages/create-vite-plugin-web-extension/templates/svelte-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/svelte-ts/package.json
@@ -15,7 +15,7 @@
     "svelte": "^4.2.18",
     "svelte-check": "^3.8.1",
     "tslib": "^2.6.3",
-    "typescript": "^5.3.2",
+    "typescript": "~5.6.3",
     "vite": "^5.3.1",
     "vite-plugin-web-extension": "^4.1.6",
     "webextension-polyfill": "^0.10.0"

--- a/packages/create-vite-plugin-web-extension/templates/vanilla-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/vanilla-ts/package.json
@@ -10,7 +10,7 @@
   },
   "devDependencies": {
     "@types/webextension-polyfill": "^0.10.0",
-    "typescript": "^5.3.2",
+    "typescript": "~5.6.3",
     "vite": "^5.0.0",
     "vite-plugin-web-extension": "^4.0.0",
     "webextension-polyfill": "^0.10.0"

--- a/packages/create-vite-plugin-web-extension/templates/vue-ts/package.json
+++ b/packages/create-vite-plugin-web-extension/templates/vue-ts/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@types/webextension-polyfill": "^0.10.0",
     "@vitejs/plugin-vue": "^4.5.0",
-    "typescript": "^5.3.2",
+    "typescript": "~5.6.3",
     "vite": "^5.0.0",
     "vite-plugin-web-extension": "^4.0.0",
     "vue-tsc": "^1.2.0",


### PR DESCRIPTION
The typescript package doesn't follow semver, see https://github.com/microsoft/TypeScript/issues/14116

Every minor version bump can lead to breaking changes, see https://github.com/microsoft/TypeScript/wiki/Breaking-Changes

Use tilde instead of caret to ensure that npm doesn't install beyond the specified minor version.