### PR TITLE
feat: Implement callback that is called after parent build is completed

### DIFF
--- a/docs/config/plugin-options.md
+++ b/docs/config/plugin-options.md
@@ -168,3 +168,11 @@ bundleInfoJsonPath?: string
 ```
 
 If set, the plugin will write a JSON file containing information about the built bundles to the specified path in the output directory. This can for example be useful for dynamically injecting content scripts/styles from background scripts.
+
+## `onBundleReady`
+
+```ts
+onBundleReady?: () => void | Promise<void>
+```
+
+This callback is invoked after the main (parent) build completes, but not for child builds triggered by different entry points. Use it to perform additional actions when the main extension bundle is ready in both development (serve) and production (build) modes.

--- a/packages/vite-plugin-web-extension/src/index.ts
+++ b/packages/vite-plugin-web-extension/src/index.ts
@@ -27,6 +27,7 @@ export default function webExtension(
     transformManifest: options.transformManifest,
     webExtConfig: options.webExtConfig,
     bundleInfoJsonPath: options.bundleInfoJsonPath,
+    onBundleReady: options.onBundleReady,
     verbose: process.argv.includes("-d") || process.argv.includes("--debug"),
     disableColors:
       process.env.CI === "true" || process.env.DISABLE_COLORS === "true", // TODO: document env var

--- a/packages/vite-plugin-web-extension/src/options.ts
+++ b/packages/vite-plugin-web-extension/src/options.ts
@@ -91,6 +91,11 @@ export interface UserOptions {
    * Output path to a JSON file containing information about the generated bundles.
    */
   bundleInfoJsonPath?: string;
+
+  /**
+   * Action to be executed after build ends.
+   */
+  onBundleReady?: () => void | Promise<void>;
 }
 
 /**
@@ -115,6 +120,7 @@ export interface ResolvedOptions {
   disableColors: boolean;
   webExtConfig?: any;
   bundleInfoJsonPath?: string;
+  onBundleReady?: () => void | Promise<void>;
 }
 
 /**

--- a/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
+++ b/packages/vite-plugin-web-extension/src/plugins/manifest-loader-plugin.ts
@@ -153,6 +153,10 @@ export function manifestLoaderPlugin(options: ResolvedOptions): vite.Plugin {
       });
     }
 
+    if (options.onBundleReady) {
+      await options.onBundleReady();
+    }
+
     await copyPublicDirToOutDir({ mode, paths });
 
     // In dev mode, open up the browser immediately after the build context is finished with the


### PR DESCRIPTION
I want to have some post-build actions executed as a part of serve of build process, and as I can see there is no such possibility yet (described here #218). I was unable to achieve that using both plugins (they are executed for every entrypoint group, which is not the case) and rollup hook overrides.

So, I've added `onBundleReady` callback to the `options`, which is called for every extension rebuild.
```ts
onBundleReady?: void | Promise<void>
```

Feedback are welcome, I am ready to improve API or something else