### PR TITLE
feat: add type safety to `webExtConfig` options

### DIFF
--- a/packages/vite-plugin-web-extension/package.json
+++ b/packages/vite-plugin-web-extension/package.json
@@ -49,6 +49,7 @@
     "lodash.uniqby": "^4.7.0",
     "md5": "^2.3.0",
     "vite": "^5.0.0 || ^4.1.4",
+    "web-ext-option-types": "8.3.0",
     "web-ext-run": "^0.2.1",
     "webextension-polyfill": "^0.10.0",
     "yaml": "^2.3.4"

--- a/packages/vite-plugin-web-extension/src/options.ts
+++ b/packages/vite-plugin-web-extension/src/options.ts
@@ -1,4 +1,5 @@
 import * as vite from "vite";
+import type * as webext from "web-ext-option-types";
 import type Browser from "webextension-polyfill";
 
 export type Manifest = any;
@@ -85,7 +86,7 @@ export interface UserOptions {
    * Optional startup configuration for web-ext. For list of options, see
    * <https://github.com/mozilla/web-ext/blob/666886f40a967b515d43cf38fc9aec67ad744d89/src/program.js#L559>.
    */
-  webExtConfig?: any;
+  webExtConfig?: webext.RunOptions;
 
   /**
    * Output path to a JSON file containing information about the generated bundles.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -212,6 +212,9 @@ importers:
       vite:
         specifier: ^5.0.0 || ^4.1.4
         version: 5.0.2(@types/node@18.11.18)(sass@1.54.8)
+      web-ext-option-types:
+        specifier: 8.3.0
+        version: 8.3.0
       web-ext-run:
         specifier: ^0.2.1
         version: 0.2.1
@@ -4517,6 +4520,10 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
+    dev: false
+
+  /web-ext-option-types@8.3.0:
+    resolution: {integrity: sha512-ZjePdOX7bfNGCaGNgNa0oCnzuGIx1oNT5/scGdgL4gAboQ/j6O0AjR7ivpYof3PTTyWgBkxNzjCWnHE0abmzHw==}
     dev: false
 
   /web-ext-run@0.2.1:


### PR DESCRIPTION
Hey! Today I wrote a script that generates TypeScript definitions for the `web-ext` command options, using the source code of `web-ext` as the source of truth.

- The repo: https://github.com/aleclarson/web-ext-option-types
- Example type definitions: https://github.com/aleclarson/web-ext-option-types/blob/main/npm/index.d.ts

Its output is published as the `web-ext-option-types` package. The plan is to have it update periodically using GitHub Actions.

Let me know if you have any questions!
