### PR TITLE
fix(dev): re-enable manifestLoaderPlugin after child builds are done

### DIFF
--- a/packages/vite-plugin-web-extension/src/index.ts
+++ b/packages/vite-plugin-web-extension/src/index.ts
@@ -12,7 +12,6 @@ export default function webExtension(
   if (process.env.VITE_PLUGIN_WEB_EXTENSION_CHILD_BUILD === "true") {
     return [];
   }
-  process.env.VITE_PLUGIN_WEB_EXTENSION_CHILD_BUILD = "true";
 
   const internalOptions: ResolvedOptions = {
     additionalInputs: options.additionalInputs ?? [],


### PR DESCRIPTION
When the Vite dev server restarts, this plugin was not working as expected. Most notably, the browser would not be re-opened, which is what drew my attention to this issue.

The fix is pretty straight-forward. Avoid keeping `process.env.VITE_PLUGIN_WEB_EXTENSION_CHILD_BUILD` set after the child builds have finished. This PR sets it to an empty string, so the `manifestLoaderPlugin` can be called again while the dev server is restarting.
