### PR TITLE
Add bun as package manager

### DIFF
--- a/packages/create-vite-plugin-web-extension/index.ts
+++ b/packages/create-vite-plugin-web-extension/index.ts
@@ -10,7 +10,7 @@ import { initProject } from "./src/initProject";
 program
   .argument("[project-name]")
   .option("-t, --template <template>")
-  .option("-p, --package-manager <package-manager>", "npm, pnpm, or yarn")
+  .option("-p, --package-manager <package-manager>", "npm, pnpm, yarn, or bun")
   .option(
     "--repo <remote-url>",
     "The repo to get templates from. Set this if working off a fork.",

--- a/packages/create-vite-plugin-web-extension/src/initProject.ts
+++ b/packages/create-vite-plugin-web-extension/src/initProject.ts
@@ -19,6 +19,7 @@ const START_COMMANDS: Record<PackageManager, string> = {
   npm: "npm run dev",
   pnpm: "pnpm dev",
   yarn: "yarn dev",
+  bun: "bun dev",
 };
 
 export async function initProject(
@@ -110,6 +111,8 @@ async function resolveOptions(
       choices.push({ title: "PNPM", value: "pnpm" });
     if (commandExists.sync("yarn"))
       choices.push({ title: "Yarn", value: "yarn" });
+    if (commandExists.sync("bun"))
+      choices.push({ title: "Bun", value: "bun" });
 
     if (choices.length > 1) {
       const res = await prompt({

--- a/packages/create-vite-plugin-web-extension/src/types.ts
+++ b/packages/create-vite-plugin-web-extension/src/types.ts
@@ -1,4 +1,4 @@
-export const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn"] as const;
+export const PACKAGE_MANAGERS = ["npm", "pnpm", "yarn", "bun"] as const;
 export type PackageManager = typeof PACKAGE_MANAGERS[number];
 
 export interface InputProjectOptions {


### PR DESCRIPTION
Adds support for Bun as an alternative package manager.
Fixes https://github.com/aklinker1/vite-plugin-web-extension/issues/238
